### PR TITLE
Add guidelines for nested TOC

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -27,3 +27,38 @@ The following rules of thumb help us organize content. They apply to all Guides 
 3. We aim to help our existing users find and understand Editions. As syntax changes across the board, it's important to give people easy access to materials that help them get up to speed quickly, as well as give newcomers a clue of how to translate older code samples from articles and Q&A into the latest and greatest approach. For Ember.js, these conversion guides will be kept in `Upgrading/Editions`, which contains content that will change as Ember grows and new features land. This guide can be linked to from throughout the rest of the Guides, rather than including much conversion content inline. This means that the new user experience is not cluttered with older syntax, but all users can still follow the trail when they need to.
 3. The Guides should be able to be read like a book, providing a thoughtful order that builds upon previous knowledge. Topics that are foundational for understanding other sections should go earlier in the list.
 4. We follow [RFC 431](https://github.com/emberjs/rfcs/pull/431) in order to improve the Guides learning experience. We aim to keep working to improve the learning flow after reaching MVP, and the RFC should not be considered "feature complete." After MVP is close to being reached, more RFCs should be proposed.
+
+
+The goal of this document is to describe how nested topics in the Ember Guides could improve UX and content navigation.
+
+## Nesting levels
+
+The Ember Guides support nested topics in the sidebar, which we will use sparingly to organize in-depth content, to a maximum of 3 levels deep.
+
+There have been multiple projects where people asked if there was an opportunity to have one
+more grouping level, such as for the contributing Guides, A11y Guides, or a Cookbook. With Octane, it became clear that
+we would need resources like a migration guide, and user feedback indicated that having these migration guides be
+one page was too overwhelming. Yet, it seemed bad to have "Octane migration" as a top level topic.
+This is where nesting can help:
+
+```
+Upgrading
+    How to upgrade
+    Ember Editions
+    Octane migration
+       Intro
+       Components
+       ...
+```
+
+In this way, we can logically group in-depth content under the right top-level topic, and create
+digestible articles, but without cluttering the main message.
+
+### Rules of thumb for using nesting
+
+Having a structure with too many levels can lead to worse navigation, without some guidelines in place.
+A third level of nesting is only appropriate when there are:
+
+- There are more than 4 possible sub-pages to group together
+- The content has already been written, and user feedback indicates that it is too much for one article
+- The information is something that every Ember developer should be aware of (i.e. it belongs in the Guides)


### PR DESCRIPTION
Right now, in the Ember Table of Contents, there can be just one topic grouping, which has an index page and subpages. This PR adds guidelines for adding one more level of nesting.

The original gist can be found here: <https://gist.github.com/jenweber/2db1fdaa39f31f45490f9126fcfa8215>

Here's an example from the ancient guides Cookbook:

<img width="313" alt="Screen Shot 2019-10-10 at 12 34 56 PM" src="https://user-images.githubusercontent.com/16627268/66588455-78eea300-eb5a-11e9-81c0-0953de7ae878.png">

