### PR TITLE
Add upgrade.emberjs.com to the list of official subdomains

### DIFF
--- a/infra_domains.md
+++ b/infra_domains.md
@@ -16,6 +16,7 @@ We will employ the use of sub-domains for official Ember projects. Right now we 
 - https://api.emberjs.com
 - https://blog.emberjs.com
 - https://help-wanted.emberjs.com
+- https://upgrade.emberjs.com
 
 Sub-domains are strongly preferred in cases where parts of our sites work best as standalone, separately maintained apps.
 


### PR DESCRIPTION
This is a proposal to add upgrade.emberjs.com to the list of official subdomains. We have already discussed it in the learning team meetings but reviews on this PR will act as collecting a consensus from the learning team before we go ahead and add it 👍 

This is a draft PR because we will merge it after the domain is live. The steps should be: 

- get all the approvals from the learning team
- put the domain live
- merge this PR 