### PR TITLE
Update Ember release instructions to cover tool-new-release

### DIFF
--- a/ember-releases/README.md
+++ b/ember-releases/README.md
@@ -1,0 +1,25 @@
+# Ember Releases
+
+When a new version of Ember is released,
+the learning team has to make sure some parts of our infrastructure are adequately updated to account for it.
+**Please update the following in the listed order**:
+
+1. Guides
+2. API documentation
+3. Release blog post
+4. Release pages
+5. Glitch Ember starter
+6. Ember Wikipedia
+
+The Guides and API docs should be published first, followed by the Release blog post. This way, links to the Guides and API docs can be included in the Release blog post. All other steps come after the blog post.
+
+There are two ways to go about it.
+Consult the relevant document for more detailed instructions:
+
+1. [Use tool-new-release](./tool-new-release.md)
+
+This tool tries to automate the process as much as possible as should be the preferred method.
+
+2. [Follow steps manually](./manual.md)
+
+If you wish to do the process manually, you will find all the steps described here.

--- a/ember-releases/README.md
+++ b/ember-releases/README.md
@@ -16,10 +16,5 @@ The Guides and API docs should be published first, followed by the Release blog 
 There are two ways to go about it.
 Consult the relevant document for more detailed instructions:
 
-1. [Use tool-new-release](./tool-new-release.md)
-
-This tool tries to automate the process as much as possible as should be the preferred method.
-
-2. [Follow steps manually](./manual.md)
-
-If you wish to do the process manually, you will find all the steps described here.
+1. [Use tool-new-release](./tool-new-release.md). The tool tries to automate the process as much as possible. This option is the preferred method.
+2. [Make a release manually](./manual.md).

--- a/ember-releases/manual.md
+++ b/ember-releases/manual.md
@@ -1,7 +1,5 @@
-# Ember Releases
+# Manual release process
 
-When a new version of Ember is released,
-the learning team has to make sure some parts of our infrastructure are adequately updated to account for it.
 **Please update the following in the listed order**:
 
 1. [Guides](#1-guides)
@@ -11,33 +9,13 @@ the learning team has to make sure some parts of our infrastructure are adequate
 5. [Glitch Ember starter](#5-glitch-ember-starter)
 6. [Ember Wikipedia](#6-ember-wikipedia)
 
-The Guides and API docs should be published first, followed by the Release blog post. This way, links to the Guides and API docs can be included in the Release blog post. All other steps come after the blog post.
-
 ## 1. Guides
 
 Instructions are found in [MAINTAINERS.md](https://github.com/ember-learn/guides-source/blob/master/MAINTAINERS.md#deploying-a-new-version).
 
 ## 2. API documentation
 
-1. Run the following script:
-
-```bash
-mkdir ember-releases
-cd ember-releases
-git clone https://github.com/ember-learn/ember-jsonapi-docs.git
-git clone https://github.com/emberjs/ember.js.git
-git clone https://github.com/emberjs/data.git
-cd ember-jsonapi-docs
-```
-2. Go to the heroku instance, navigate to `Settings`, click `reveal config vars` and use the values seen there as values for the following variables in your local environment:
-    1. `AWS_ACCESS_KEY`
-    2. `AWS_ACCESS_KEY_ID`
-    3. `AWS_SECRET_ACCESS_KEY`
-    4. `AWS_SECRET_KEY`
-    5. `AWS_SHOULD_PUBLISH`
-4. Run `yarn run start --sync`
-5. Wait and confirm there were no errors
-6. Done!
+Instructions are found in [RELEASE.md](https://github.com/ember-learn/ember-jsonapi-docs/blob/master/EMBER_RELEASE.md).
 
 ## 3. Release blog post
 

--- a/ember-releases/tool-new-release.md
+++ b/ember-releases/tool-new-release.md
@@ -1,19 +1,25 @@
 # tool-new-release process
 
-At the moment the tool only handles minor version bumps and requires the user to specify the version, like so:
+At the moment, the tool only handles minor version bumps and requires you to specify the version:
 
 ```bash
+# Going from 3.23 (current) to 3.24 (new)
 tool-new-release --version 3.24.0
-```
 
-To start the release process using `tool-new-release`, do the following:
+To start the release process using `tool-new-release`:
 
 1. Go to the [releases page](https://github.com/ember-learn/tool-new-release/releases)
-2. Find the most recent draft
-3. Expand the "Assets" panel
-4. Download the binary that corresponds to your operating system
-5. Run the binary
-5.1. If you are on macOS you will need to right-click and "Open" the binary to get around the security check, since the binary is not signed
-6. Follow the instructions presented carefully
+2. Find the most recent **draft**
 
-For more detailed information refer to the [README](https://github.com/ember-learn/tool-new-release).
+   <img width="900" alt="The top of the page shows the most recent draft" src="https://user-images.githubusercontent.com/16869656/104086072-db9a8700-5254-11eb-84af-6319f59254d4.png">
+3. Expand the **Assets** panel
+
+    <img width="900" alt="Click Assets to see a binary for each operating system" src="https://user-images.githubusercontent.com/16869656/104086120-41870e80-5255-11eb-8500-8102684db40f.png">
+
+4. Download the binary that corresponds to your operating system
+5. Run the binary. If you are on macOS, you will need to right-click on the binary file, then click **Open** to bypass security check (the binary is not signed).
+
+    <img width="900" alt="On Mac, right-click on the binary file and click Open" src="https://user-images.githubusercontent.com/16869656/104086195-ed305e80-5255-11eb-97e1-00388e2ba85c.png">
+6. Carefully follow the instructions presented in the terminal
+
+For more information about tool-new-release, please see [README](https://github.com/ember-learn/tool-new-release).

--- a/ember-releases/tool-new-release.md
+++ b/ember-releases/tool-new-release.md
@@ -1,0 +1,19 @@
+# tool-new-release process
+
+At the moment the tool only handles minor version bumps and requires the user to specify the version, like so:
+
+```bash
+tool-new-release --version 3.24.0
+```
+
+To start the release process using `tool-new-release`, do the following:
+
+1. Go to the [releases page](https://github.com/ember-learn/tool-new-release/releases)
+2. Find the most recent draft
+3. Expand the "Assets" panel
+4. Download the binary that corresponds to your operating system
+5. Run the binary
+5.1. If you are on macOS you will need to right-click and "Open" the binary to get around the security check, since the binary is not signed
+6. Follow the instructions presented carefully
+
+For more detailed information refer to the [README](https://github.com/ember-learn/tool-new-release).


### PR DESCRIPTION
These changes complicate the structure of the repo slightly, but I wanted to both have a written record of what the manual steps are and keep them separate from the instructions on how to run the tool.
Please review and comment!